### PR TITLE
Allow board to provide libreference-ril

### DIFF
--- a/reference-ril/Android.mk
+++ b/reference-ril/Android.mk
@@ -1,5 +1,7 @@
 # Copyright 2006 The Android Open Source Project
 
+ifneq ($(BOARD_PROVIDES_LIBREFERENCE_RIL),true)
+
 # XXX using libutils for simulator build only...
 #
 LOCAL_PATH:= $(call my-dir)
@@ -45,3 +47,5 @@ else
   LOCAL_MODULE:= reference-ril
   include $(BUILD_EXECUTABLE)
 endif
+
+endif # BOARD_PROVIDES_LIBREFERENCE_RIL


### PR DESCRIPTION
This also fix breaking ninja if BOARD_PROVIDES_LIBRIL is set
while libreference-ril still refers to libril, which is not exists.

Set both BOARD_PROVIDES_LIBRIL and BOARD_PROVIDES_LIBREFERENCE_RIL
to true make ninja happy.

Change-Id: I4f164178ae1c77dae420544ba7cadef8cb7ea883